### PR TITLE
Feature: additional funtionality

### DIFF
--- a/slip.js
+++ b/slip.js
@@ -241,7 +241,7 @@ window['Slip'] = (function(){
                         var move = this.getAbsoluteMovement();
 
                         if (move.x > 20 && move.y < Math.max(100, this.target.height)) {
-                            if (this.dispatch(this.target.originalTarget, 'beforeswipe')) {
+                            if (this.dispatch(this.target.originalTarget, 'beforeswipe', {directionX: move.directionX, directionY: move.directionY})) {
                                 this.setState(this.states.swipe);
                                 return false;
                             } else {
@@ -709,8 +709,8 @@ window['Slip'] = (function(){
                 x: Math.abs(this.latestPosition.x - this.startPosition.x),
                 y: Math.abs(this.latestPosition.y - this.startPosition.y),
                 time:this.latestPosition.time - this.startPosition.time,
-                xDirection:this.latestPosition.x - this.startPosition.x < 0 ? 'left' : 'right',
-                yDirection:this.latestPosition.y - this.startPosition.y < 0 ? 'up' : 'down',
+                directionX:this.latestPosition.x - this.startPosition.x < 0 ? 'left' : 'right',
+                directionY:this.latestPosition.y - this.startPosition.y < 0 ? 'up' : 'down',
             };
         },
 

--- a/slip.js
+++ b/slip.js
@@ -709,6 +709,8 @@ window['Slip'] = (function(){
                 x: Math.abs(this.latestPosition.x - this.startPosition.x),
                 y: Math.abs(this.latestPosition.y - this.startPosition.y),
                 time:this.latestPosition.time - this.startPosition.time,
+                xDirection:this.latestPosition.x - this.startPosition.x < 0 ? 'left' : 'right',
+                yDirection:this.latestPosition.y - this.startPosition.y < 0 ? 'up' : 'down',
             };
         },
 

--- a/slip.js
+++ b/slip.js
@@ -316,22 +316,12 @@ window['Slip'] = (function(){
                     },
 
                     onEnd: function() {
-                        var dx = this.latestPosition.x - this.previousPosition.x;
-                        var dy = this.latestPosition.y - this.previousPosition.y;
-                        var velocity = Math.sqrt(dx*dx + dy*dy) / (this.latestPosition.time - this.previousPosition.time + 1);
-
                         var move = this.getAbsoluteMovement();
-                        var swiped = velocity > 0.6 && move.time > 110;
+                        var velocity = Math.abs(move.x) / move.time;
 
-						var direction;
-						if (dx > 0) {
-							direction = "right";
-						} else {
-							direction = "left";
-						}
-
+                        var swiped = velocity > 1 && move.time > 110;
                         if (swiped) {
-                            if (this.dispatch(this.target.node, 'swipe', {direction: direction, originalIndex: originalIndex})) {
+                            if (this.dispatch(this.target.node, 'swipe', {direction: move.directionX, originalIndex: originalIndex})) {
                                 swipeSuccess = true; // can't animate here, leaveState overrides anim
                             }
                         }

--- a/slip.js
+++ b/slip.js
@@ -135,7 +135,8 @@ window['Slip'] = (function(){
 
         if (!this || this === window) return new Slip(container, options);
 
-        this.options = options;
+        this.options = options = options || {};
+        this.options.keepSwipingPercent = options.keepSwipingPercent || 0;
 
         // Functions used for as event handlers need usable `this` and must not change to be removable
         this.cancel = this.setState.bind(this, this.states.idle);
@@ -317,9 +318,13 @@ window['Slip'] = (function(){
 
                     onEnd: function() {
                         var move = this.getAbsoluteMovement();
-                        var velocity = Math.abs(move.x) / move.time;
+                        var velocity = move.x / move.time;
 
-                        var swiped = velocity > 1 && move.time > 110;
+                        // How far out has the item been swiped?
+                        var swipedPercent = Math.abs((this.startPosition.x - this.previousPosition.x) / this.container.clientWidth) * 100;
+
+                        var swiped = (velocity > 1 && move.time > 110) || (this.options.keepSwipingPercent && swipedPercent > this.options.keepSwipingPercent);
+
                         if (swiped) {
                             if (this.dispatch(this.target.node, 'swipe', {direction: move.directionX, originalIndex: originalIndex})) {
                                 swipeSuccess = true; // can't animate here, leaveState overrides anim

--- a/slip.js
+++ b/slip.js
@@ -137,6 +137,8 @@ window['Slip'] = (function(){
 
         this.options = options = options || {};
         this.options.keepSwipingPercent = options.keepSwipingPercent || 0;
+        this.options.minimumSwipeVelocity = options.minimumSwipeVelocity || 1;
+        this.options.minimumSwipeTime = options.minimumSwipeTime || 110;
 
         // Functions used for as event handlers need usable `this` and must not change to be removable
         this.cancel = this.setState.bind(this, this.states.idle);
@@ -323,7 +325,7 @@ window['Slip'] = (function(){
                         // How far out has the item been swiped?
                         var swipedPercent = Math.abs((this.startPosition.x - this.previousPosition.x) / this.container.clientWidth) * 100;
 
-                        var swiped = (velocity > 1 && move.time > 110) || (this.options.keepSwipingPercent && swipedPercent > this.options.keepSwipingPercent);
+                        var swiped = (velocity > this.options.minimumSwipeVelocity && move.time > this.options.minimumSwipeTime) || (this.options.keepSwipingPercent && swipedPercent > this.options.keepSwipingPercent);
 
                         if (swiped) {
                             if (this.dispatch(this.target.node, 'swipe', {direction: move.directionX, originalIndex: originalIndex})) {


### PR DESCRIPTION
This is the Nona-Creative PR. There is an upstream PR that matches this: https://github.com/pornel/slip/pull/56

Return directionX and directionY in the getAbsoluteMovement() method.

Return the x and y direction with beforeswipe. Enables developers
to make better decisions when receiving this event.

Refactored swipe event with a much simpler velocity calculation.

Use the direction from the new getAbsoluteMovement() method instead of recalculating in the swipe event. Fixes a bug where the direction for a right swipe would sometimes be reported as a left swipe. This was due to the direction calculation that has now been replaced in the swipe event's onEnd method.

Ability to define a "keep swiping" trigger point to be passed in to the constructor that lets you set a percentage (in terms of how far out the left- or rightmost edge of the list item has moved across the width of the list) that will trigger a swipe regardless of velocity. This allows a user to swipe out past x percent, think for a while, and if they still want it to swipe out let go and have it swipe out if past the minimum percent. Makes the swiping gestures behave more like they do in native Android applications.

The default value for swipe percent is 0 if it is missing, which returns false for the check.

Fixed a bug with the assignment of options in the constructor.

Configurable velocity and time for swipe with defaults for when these configurable options are not present which match the original settings.
